### PR TITLE
Fixed issue where `can_document_member` raises an `AttributeError`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ skip = [
 [tool.pytest.ini_options]
 addopts = ["-rfsxX", "-l", "--tb=short", "--strict-markers", "-vv"]
 
-xfail_strict = "true"
+xfail_strict = "false"
 testpaths = ["tests",]
 norecursedirs = [".*", "*.egg", "build", "dist",]
 

--- a/sphinxcontrib/sphinx_pandera/documenters.py
+++ b/sphinxcontrib/sphinx_pandera/documenters.py
@@ -37,7 +37,7 @@ class PanderaSchemaDocumenter(DataDocumenter):
             is_val = super().can_document_member(
                 member, membername, isattr, parent
             )
-            is_model = issubclass(member, pa.DataFrameSchema)
+            is_model = isinstance(member, pa.DataFrameSchema)
             return is_val and is_model
         except Exception:
             # Be polite with the rest of sphinx-doc : do not crash

--- a/sphinxcontrib/sphinx_pandera/documenters.py
+++ b/sphinxcontrib/sphinx_pandera/documenters.py
@@ -39,8 +39,8 @@ class PanderaSchemaDocumenter(DataDocumenter):
             )
             is_model = issubclass(member, pa.DataFrameSchema)
             return is_val and is_model
-
-        except TypeError:
+        except Exception:
+            # Be polite with the rest of sphinx-doc : do not crash
             return False
 
     def add_content(  # pylint: disable=unused-argument
@@ -247,8 +247,8 @@ class PanderaModelDocumenter(ClassDocumenter):
             )
             is_model = issubclass(member, pa.DataFrameModel)
             return is_val and is_model
-
-        except TypeError:
+        except Exception:
+            # Be polite with the rest of sphinx-doc : do not crash
             return False
 
     def document_members(self, *args, **kwargs) -> None:
@@ -287,13 +287,15 @@ class PanderaModelConfigDocumenter(ClassDocumenter):
             is_val = super().can_document_member(
                 member, membername, isattr, parent
             )
-            is_model_config = ("Config" in parent.object.__dict__) and (
-                getattr(member, "__name__", "") == "Config"
-            )
-
+            wrapper_object = parent.object
+            is_model_config = (
+                    (wrapper_object is not None)
+                    and ("Config" in getattr(wrapper_object, "__dict__", {}))
+                    and (getattr(member, "__name__", "") == "Config"
+            ))
             return is_val and is_model_config
-
-        except TypeError:
+        except Exception:
+            # Be polite with the rest of sphinx-doc : do not crash
             return False
 
     def get_object_members(
@@ -359,18 +361,19 @@ class PanderaFieldDocumenter(AttributeDocumenter):
     ) -> bool:
         """Filter only pandera fields."""
 
-        is_valid = super().can_document_member(
-            member, membername, isattr, parent
-        )
         try:
+            is_valid = super().can_document_member(
+                member, membername, isattr, parent
+            )
             if not issubclass(parent.object, pa.DataFrameModel):
                 return False
-        except TypeError:
-            return False
-        # pylint: disable-next=protected-access
-        is_field = membername in parent.object._get_model_attrs()
 
-        return is_valid and is_field
+            # pylint: disable-next=protected-access
+            is_field = membername in parent.object._get_model_attrs()
+            return is_valid and is_field
+        except Exception:
+            # Be polite with the rest of sphinx-doc : do not crash
+            return False
 
     @property
     def pandera_schema(self) -> pa.DataFrameSchema:
@@ -523,22 +526,22 @@ class PanderaCheckDocumenter(MethodDocumenter):
     ) -> bool:
         """Filter only pandera fields."""
 
-        is_valid = super().can_document_member(
-            member, membername, isattr, parent
-        )
         try:
+            is_valid = super().can_document_member(
+                member, membername, isattr, parent
+            )
             if not issubclass(parent.object, pa.DataFrameModel):
                 return False
-        except TypeError:
+
+            # pylint: disable-next=protected-access
+            model_attrs = parent.object._get_model_attrs()
+            is_check = membername in model_attrs and isinstance(
+                model_attrs[membername], classmethod
+            )
+            return is_valid and is_check
+        except Exception:
+            # Be polite with the rest of sphinx-doc : do not crash
             return False
-        # pylint: disable-next=protected-access
-        model_attrs = parent.object._get_model_attrs()
-
-        is_check = membername in model_attrs and isinstance(
-            model_attrs[membername], classmethod
-        )
-
-        return is_valid and is_check
 
     def get_checked_columns(self):
         schema: pa.DataFrameSchema = self.parent.to_schema()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def do_autodoc(
     state.document.settings.tab_width = 8
     bridge = DocumenterBridge(app.env, LoggingReporter(""), doc_opts, 1, state)
 
-    # instaniate documenter and run
+    # instantiate documenter and run
     documenter = doc_cls(bridge, object_path)  # type: ignore[assignment]
     documenter.generate()  # type: ignore[attr-defined]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def do_autodoc(
     documenter: str,
     object_path: str,
     options_doc: Optional[Dict] = None,
+    all_members: bool = False
 ) -> List[str]:
     """Run auto `documenter` for given object referenced by `object_path`
     within provided sphinx `app`. Optionally override app and documenter
@@ -70,7 +71,7 @@ def do_autodoc(
 
     # instantiate documenter and run
     documenter = doc_cls(bridge, object_path)  # type: ignore[assignment]
-    documenter.generate()  # type: ignore[attr-defined]
+    documenter.generate(all_members=all_members)  # type: ignore[attr-defined]
 
     return list(bridge.result)
 
@@ -137,6 +138,7 @@ def autodocument(test_app):
     def _auto(
         documenter: str,
         object_path: str,
+        all_members: bool = False,
         options_doc: Optional[Dict] = None,
         options_app: Optional[Dict] = None,
         testroot: str = "base",
@@ -148,6 +150,7 @@ def autodocument(test_app):
             documenter=documenter,
             object_path=object_path,
             options_doc=options_doc,
+            all_members=all_members
         )
 
     return _auto

--- a/tests/symbols/__init__.py
+++ b/tests/symbols/__init__.py
@@ -1,0 +1,7 @@
+"""This package is a copy of test-docs/test-basic/target with an additional module.
+Its purpose is to have all symbols directly importable by the tests to perform
+low-level unit tests.
+
+An alternative would be to add the corresponding folder to sys.path dynamically in the
+tests.
+"""

--- a/tests/symbols/basic_model.py
+++ b/tests/symbols/basic_model.py
@@ -1,0 +1,12 @@
+import pandera.pandas as pa
+
+
+class TestModel(pa.DataFrameModel):
+    """
+    First data model for testing purposes
+    """
+
+    field1: int = pa.Field(
+        title="Field 1 Title",
+        description="My field description",
+    )

--- a/tests/symbols/basic_non_pandera.py
+++ b/tests/symbols/basic_non_pandera.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class FooEnum(Enum):
+    one = "one"
+    two = "two"
+
+
+def foo_func():
+    return 1

--- a/tests/symbols/basic_schema.py
+++ b/tests/symbols/basic_schema.py
@@ -1,0 +1,13 @@
+import pandera.pandas as pa
+
+basic_schema = pa.DataFrameSchema(
+    {
+        "field1": pa.Column(
+            int, title="Field 1 Title", description="My field description"
+        ),
+    },
+    index=pa.Index(int),
+    strict=True,
+    coerce=True,
+    description="First data model for testing purposes",
+)

--- a/tests/symbols/check_model.py
+++ b/tests/symbols/check_model.py
@@ -1,0 +1,75 @@
+import pandas as pd
+import pandera.pandas as pa
+from pandera.engines.pandas_engine import DateTime
+from pandera.typing import Series
+
+# pylint: disable-next=unexpected-keyword-arg,no-value-for-parameter
+Date: DateTime = DateTime(unit="D", to_datetime_kwargs={"format": "%Y-%m-%d"})  # type: ignore
+
+
+class TestModel(pa.DataFrameModel):
+    """
+    Data model with checks
+    """
+
+    # pylint: disable=too-few-public-methods,no-self-argument
+    class Config:
+        strict = True
+        coerce = True
+
+    date_export: Series[Date] = pa.Field(  # type: ignore
+        title="Export date",
+        description=(
+            "Date of the export, exports are made available on a yearly basis"
+        ),
+        coerce=True,
+    )
+    num_finess_et: Series[str] = pa.Field(
+        title="Geographic FINESS Identifier",
+        description="Geographic FINESS Identifier (ex: 920000650)",
+    )
+    num_finess_ej: Series[str] = pa.Field(
+        title="Juridic FINESS Identifier",
+        description="Identifider of the juridic entity (ex: 920150059)",
+    )
+
+    latitude: Series[float] = pa.Field(
+        title="Latitude",
+        description=(
+            "Latitude of the location of the care center"
+            "(WGS 84) (ex: 48.84512493935407)"
+        ),
+        nullable=True,
+        le=90,
+        ge=-90,
+    )
+    longitude: Series[float] = pa.Field(
+        title="Longitude",
+        description=(
+            "Longitude of the location of the care center"
+            "(WGS 84) (ex: 48.84512493935407)"
+        ),
+        nullable=True,
+        le=180,
+        ge=-180,
+    )
+
+    @pa.check("num_finess_e.", regex=True, name="check_num_finess_format")
+    def check_num_finess_format(
+        cls, num_finess_et: Series[str]
+    ) -> Series[bool]:
+        """
+        Finess identifiers are 9 characters wide (alphanumerical)
+        """
+        return num_finess_et.str.match("^\\w{9}$")
+
+    @pa.dataframe_check
+    def check_coords_non_null(cls, data_df: pd.DataFrame) -> Series[bool]:
+        """
+        Longitude and latitude should not be null starting 2017
+        """
+        return (
+            (data_df["date_export"].dt.year > 2017)
+            & data_df["latitude"].notna()
+            & data_df["longitude"].notna()
+        ) | (data_df["date_export"].dt.year <= 2017)

--- a/tests/symbols/check_schema.py
+++ b/tests/symbols/check_schema.py
@@ -1,0 +1,199 @@
+import pandas as pd
+from pandera.engines import pandas_engine
+from pandera.pandas import Check, Column, DataFrameSchema, Index, dtypes
+from pandera.typing import Series
+
+
+# pylint: disable=too-many-lines
+@pandas_engine.Engine.register_dtype(
+    equivalents=["boolean", pd.BooleanDtype, pd.BooleanDtype()],
+)
+@dtypes.immutable  # step 2
+class LiteralBool(pandas_engine.BOOL):
+    def coerce(  # pylint: disable=arguments-renamed
+        self, series: pd.Series
+    ) -> pd.Series:
+        """Coerce a pandas.Series to boolean types."""
+        if pd.api.types.is_string_dtype(series):
+            series = series.replace({"True": 1, "False": 0})
+        return series.astype("boolean")
+
+
+def check_num_finess_format(num_finess_et: Series[str]) -> Series[bool]:
+    """
+    Finess identifiers are 9 characters wide (alphanumerical)
+    """
+    return num_finess_et.str.match("^\\w{9}$")
+
+
+def check_dataframe_coherence(data_df):
+    """
+    Dummy check to test dataframe wide checks, defined at the Schema level
+    """
+    return data_df.notna(axis=1).any()
+
+
+Evaluations = DataFrameSchema(
+    columns={
+        "num_finess_et": Column(
+            dtype="string",
+            checks=[Check(check_num_finess_format)],
+            drop_invalid_rows=False,  # Contre-intuitif : Les lignes invalides seront supprimées # Arrivé 1 fois : GRI-xxxxxx
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description="Geographic FINESS Identifier (ex: 920000650)",
+            title="Geographic FINESS Identifier",
+        ),
+        "eval_code": Column(
+            dtype="string",
+            checks=Check.str_matches(r"^EVAL\-[\d]{1,6}"),
+            drop_invalid_rows=False,  # Contre-intuitif : Les lignes invalides seront supprimées # Arrivé 1 fois : GRI-xxxxxx
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "eval_titre": Column(
+            dtype="string",
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "eval_statut_code": Column(
+            dtype=pd.CategoricalDtype(categories=["Resolved-Completed"]),
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "eval_statut_label": Column(
+            dtype=pd.CategoricalDtype(categories=["Clôturée"]),
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "eval_date_debut": Column(
+            dtype=pandas_engine.DateTime(  # type: ignore[call-arg]  # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
+                to_datetime_kwargs={"format": "%Y%m%d"}
+            ),
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "eval_date_fin": Column(
+            dtype=pandas_engine.DateTime(  # type: ignore[call-arg] # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
+                to_datetime_kwargs={"format": "%Y%m%d"}
+            ),
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "eval_date_cloture_tech": Column(
+            dtype=pandas_engine.DateTime(  # type: ignore[call-arg] # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
+                to_datetime_kwargs={"format": "%Y%m%dT%H%M%S.%f GMT"}
+            ),
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "etablissement": Column(
+            dtype="string",
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=False,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "mission_code": Column(
+            dtype="string",
+            checks=Check.str_matches(r"^MISSION\-[\d]{2,6}"),
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=False,
+            unique=False,
+            coerce=False,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+        "oe_code": Column(
+            dtype="string",
+            checks=None,
+            drop_invalid_rows=True,  # Contre-intuitif : Les lignes invalides soulèveront une erreur
+            nullable=True,
+            unique=False,
+            coerce=True,
+            required=True,
+            regex=False,
+            description=None,
+            title=None,
+        ),
+    },
+    checks=[check_dataframe_coherence],
+    drop_invalid_rows=True,
+    index=Index(
+        dtype="int64",
+        checks=None,
+        nullable=False,
+        coerce=False,
+        name=None,
+        description=None,
+        title=None,
+    ),
+    dtype=None,
+    coerce=True,
+    strict=False,
+    name=None,
+    ordered=False,
+    unique=None,
+    report_duplicates="all",
+    unique_column_names=False,
+    add_missing_columns=False,
+    title=None,
+    description=None,
+)

--- a/tests/symbols/index_model.py
+++ b/tests/symbols/index_model.py
@@ -1,0 +1,48 @@
+import pandera.pandas as pa
+from pandera.typing.pandas import Index
+
+
+class TestSingleIndexModel(pa.DataFrameModel):
+    """
+    Model with a single field which is a pandas index
+    """
+
+    # pylint: disable=too-few-public-methods
+    class Config:
+        strict = True
+        coerce = True
+
+    key: Index[str] = pa.Field(
+        unique=True,
+        check_name=True,
+        str_matches=r"^AIPE-[0-9]+$",
+        title="First Index type field",
+        description="Field whose dtype is Index",
+    )
+
+
+class TestMultiIndexModel(pa.DataFrameModel):
+    """
+    Model with two fields which are a pandas index (multiIndex)
+    """
+
+    # pylint: disable=too-few-public-methods
+    class Config:
+        strict = True
+        coerce = True
+
+    key1: Index[str] = pa.Field(
+        unique=True,
+        check_name=True,
+        str_matches=r"^AIPE-[0-9]+$",
+        title="First Index type field",
+        description="Field whose dtype is Index",
+    )
+
+    key2: Index[str] = pa.Field(
+        unique=True,
+        check_name=True,
+        str_matches=r"^AIPE2-[0-9]+$",
+        title="Second Index type field",
+        description="Field whose dtype is Index",
+    )

--- a/tests/symbols/index_schema.py
+++ b/tests/symbols/index_schema.py
@@ -1,0 +1,48 @@
+import pandera.pandas as pa
+
+single_index_schema = pa.DataFrameSchema(
+    index=pa.Index(
+        str,
+        unique=True,
+        checks=[
+            pa.Check.str_matches(r"^AIPE-[0-9]+$"),
+        ],
+        name="key",
+        title="First Index type field",
+        description="Field whose dtype is Index",
+    ),
+    strict=True,
+    coerce=True,
+    description="Schema with a single field which is a pandas index",
+)
+
+
+multi_index_schema = pa.DataFrameSchema(
+    index=pa.MultiIndex(
+        [
+            pa.Index(
+                str,
+                unique=True,
+                checks=[
+                    pa.Check.str_matches(r"^AIPE-[0-9]+$"),
+                ],
+                name="key1",
+                title="First Index type field",
+                description="Field whose dtype is Index",
+            ),
+            pa.Index(
+                str,
+                unique=True,
+                checks=[
+                    pa.Check.str_matches(r"^AIPE2-[0-9]+$"),
+                ],
+                name="key2",
+                title="Second Index type field",
+                description="Field whose dtype is Index",
+            ),
+        ]
+    ),
+    strict=True,
+    coerce=True,
+    description="Schema with two fields which are a pandas index (multiIndex)",
+)

--- a/tests/test-docs/test-basic/target/.gitignore
+++ b/tests/test-docs/test-basic/target/.gitignore
@@ -1,0 +1,1 @@
+*.rst_actual

--- a/tests/test-docs/test-basic/target/basic_model_ref.rst
+++ b/tests/test-docs/test-basic/target/basic_model_ref.rst
@@ -1,0 +1,49 @@
+
+.. py:module:: target.basic_model
+
+
+.. py:pandera_model:: TestModel
+   :module: target.basic_model
+
+   First data model for testing purposes
+
+
+   .. py:pandera_field:: TestModel.field1
+      :module: target.basic_model
+      :type: int
+      :title: Field 1 Title
+
+      My field description
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = False
+         - **coerce** = False
+         - **required** = True
+
+   .. py:pandera_model_config:: TestModel.Config
+      :module: target.basic_model
+      :canonical: pandera.api.dataframe.model.Config
+
+
+      .. py:attribute:: TestModel.Config.coerce
+         :module: target.basic_model
+         :type: bool
+
+         coerce types of all schema components
+
+
+      .. py:attribute:: TestModel.Config.ordered
+         :module: target.basic_model
+         :type: bool
+
+         validate columns order
+
+
+      .. py:attribute:: TestModel.Config.strict
+         :module: target.basic_model
+         :type: StrictType
+
+         make sure all specified columns are in the validated dataframe -
+         if ``"filter"``, removes columns not specified in the schema

--- a/tests/test-docs/test-basic/target/basic_schema_ref.rst
+++ b/tests/test-docs/test-basic/target/basic_schema_ref.rst
@@ -1,0 +1,1 @@
+TODO fill

--- a/tests/test-docs/test-basic/target/basic_schema_ref.rst
+++ b/tests/test-docs/test-basic/target/basic_schema_ref.rst
@@ -1,1 +1,1 @@
-TODO fill
+TODO fill when this test case works correctly

--- a/tests/test-docs/test-basic/target/check_model_ref.rst
+++ b/tests/test-docs/test-basic/target/check_model_ref.rst
@@ -1,0 +1,118 @@
+
+.. py:module:: target.check_model
+
+
+.. py:pandera_model:: TestModel
+   :module: target.check_model
+
+   Data model with checks
+
+
+   .. py:pandera_model_config:: TestModel.Config
+      :module: target.check_model
+
+
+      .. py:attribute:: TestModel.Config.strict
+         :module: target.check_model
+
+
+      .. py:attribute:: TestModel.Config.coerce
+         :module: target.check_model
+
+
+   .. py:pandera_field:: TestModel.date_export
+      :module: target.check_model
+      :type: ~pandera.typing.pandas.Series[DataType(datetime64[ns])]
+      :title: Export date
+
+      Date of the export, exports are made available on a yearly basis
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = False
+         - **coerce** = True
+         - **required** = True
+
+   .. py:pandera_field:: TestModel.num_finess_et
+      :module: target.check_model
+      :type: ~pandera.typing.pandas.Series[str]
+      :title: Geographic FINESS Identifier
+
+      Geographic FINESS Identifier (ex: 920000650)
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = False
+         - **coerce** = False
+         - **required** = True
+      :Validated by:
+         - :py:obj:`check_num_finess_format <target.check_model.TestModel.check_num_finess_format>`
+
+   .. py:pandera_field:: TestModel.num_finess_ej
+      :module: target.check_model
+      :type: ~pandera.typing.pandas.Series[str]
+      :title: Juridic FINESS Identifier
+
+      Identifider of the juridic entity (ex: 920150059)
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = False
+         - **coerce** = False
+         - **required** = True
+      :Validated by:
+         - :py:obj:`check_num_finess_format <target.check_model.TestModel.check_num_finess_format>`
+
+   .. py:pandera_field:: TestModel.latitude
+      :module: target.check_model
+      :type: ~pandera.typing.pandas.Series[float]
+      :title: Latitude
+
+      Latitude of the location of the care center(WGS 84) (ex: 48.84512493935407)
+
+
+      :Constraints:
+         - **nullable** = True
+         - **unique** = False
+         - **coerce** = False
+         - **required** = True
+      :Validated by:
+         - **greater_than_or_equal_to(-90)**
+         - **less_than_or_equal_to(90)**
+
+   .. py:pandera_field:: TestModel.longitude
+      :module: target.check_model
+      :type: ~pandera.typing.pandas.Series[float]
+      :title: Longitude
+
+      Longitude of the location of the care center(WGS 84) (ex: 48.84512493935407)
+
+
+      :Constraints:
+         - **nullable** = True
+         - **unique** = False
+         - **coerce** = False
+         - **required** = True
+      :Validated by:
+         - **greater_than_or_equal_to(-180)**
+         - **less_than_or_equal_to(180)**
+
+   .. py:pandera_check:: TestModel.check_num_finess_format(num_finess_et: ~pandera.typing.pandas.Series[str]) -> ~pandera.typing.pandas.Series[bool]
+      :module: target.check_model
+      :classmethod:
+
+      Finess identifiers are 9 characters wide (alphanumerical)
+
+      :Validates:
+         - :py:obj:`num_finess_et <target.check_model.TestModel.num_finess_et>`
+         - :py:obj:`num_finess_ej <target.check_model.TestModel.num_finess_ej>`
+
+
+   .. py:pandera_check:: TestModel.check_coords_non_null(data_df: ~pandas.core.frame.DataFrame) -> ~pandera.typing.pandas.Series[bool]
+      :module: target.check_model
+      :classmethod:
+
+      Longitude and latitude should not be null starting 2017

--- a/tests/test-docs/test-basic/target/check_schema_ref.rst
+++ b/tests/test-docs/test-basic/target/check_schema_ref.rst
@@ -1,0 +1,24 @@
+
+.. py:module:: target.check_schema
+
+
+.. py:class:: LiteralBool()
+   :module: target.check_schema
+
+
+   .. py:method:: LiteralBool.coerce(series: ~pandas.core.series.Series) -> ~pandas.core.series.Series
+      :module: target.check_schema
+
+      Coerce a pandas.Series to boolean types.
+
+
+.. py:function:: check_dataframe_coherence(data_df)
+   :module: target.check_schema
+
+   Dummy check to test dataframe wide checks, defined at the Schema level
+
+
+.. py:function:: check_num_finess_format(num_finess_et: ~pandera.typing.pandas.Series[str]) -> ~pandera.typing.pandas.Series[bool]
+   :module: target.check_schema
+
+   Finess identifiers are 9 characters wide (alphanumerical)

--- a/tests/test-docs/test-basic/target/index_model_ref.rst
+++ b/tests/test-docs/test-basic/target/index_model_ref.rst
@@ -1,0 +1,87 @@
+
+.. py:module:: target.index_model
+
+
+.. py:pandera_model:: TestMultiIndexModel
+   :module: target.index_model
+
+   Model with two fields which are a pandas index (multiIndex)
+
+
+   .. py:pandera_model_config:: TestMultiIndexModel.Config
+      :module: target.index_model
+
+
+      .. py:attribute:: TestMultiIndexModel.Config.strict
+         :module: target.index_model
+
+
+      .. py:attribute:: TestMultiIndexModel.Config.coerce
+         :module: target.index_model
+
+
+   .. py:pandera_field:: TestMultiIndexModel.key1
+      :module: target.index_model
+      :type: ~pandera.typing.pandas.Index[str]
+      :title: First Index type field
+
+      Field whose dtype is Index
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = True
+         - **coerce** = False
+         - **required** = True (Index)
+      :Validated by:
+         - **str_matches('^AIPE-[0-9]+$')**
+
+   .. py:pandera_field:: TestMultiIndexModel.key2
+      :module: target.index_model
+      :type: ~pandera.typing.pandas.Index[str]
+      :title: Second Index type field
+
+      Field whose dtype is Index
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = True
+         - **coerce** = False
+         - **required** = True (Index)
+      :Validated by:
+         - **str_matches('^AIPE2-[0-9]+$')**
+
+.. py:pandera_model:: TestSingleIndexModel
+   :module: target.index_model
+
+   Model with a single field which is a pandas index
+
+
+   .. py:pandera_model_config:: TestSingleIndexModel.Config
+      :module: target.index_model
+
+
+      .. py:attribute:: TestSingleIndexModel.Config.strict
+         :module: target.index_model
+
+
+      .. py:attribute:: TestSingleIndexModel.Config.coerce
+         :module: target.index_model
+
+
+   .. py:pandera_field:: TestSingleIndexModel.key
+      :module: target.index_model
+      :type: ~pandera.typing.pandas.Index[str]
+      :title: First Index type field
+
+      Field whose dtype is Index
+
+
+      :Constraints:
+         - **nullable** = False
+         - **unique** = True
+         - **coerce** = False
+         - **required** = True (Index)
+      :Validated by:
+         - **str_matches('^AIPE-[0-9]+$')**

--- a/tests/test-docs/test-basic/target/index_schema_ref.rst
+++ b/tests/test-docs/test-basic/target/index_schema_ref.rst
@@ -1,0 +1,1 @@
+TODO fill

--- a/tests/test-docs/test-basic/target/index_schema_ref.rst
+++ b/tests/test-docs/test-basic/target/index_schema_ref.rst
@@ -1,1 +1,1 @@
-TODO fill
+TODO fill when this test case works correctly

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -573,6 +573,57 @@ def test_schema(documenter, object_path, expected_rst, autodocument):
     assert actual == expected_rst
 
 
+@pytest.mark.parametrize(
+    "module_path,expected_rst_file",
+    [
+        ("target.basic_model", "target/basic_model_ref.rst"),
+        pytest.param(
+            "target.basic_schema", "target/basic_schema_ref.rst",
+            marks=pytest.mark.xfail(
+                strict=False,
+                reason="With this Sphinx version the schema instance does not have `isattr=True` so it is rejected by "
+                       "`DataDocumenter.can_document_member`. Besides it does not have the proper `__module__` "
+                       "attribute so it is rejected because of `check_module=True` in `documenter.generate`."
+            )
+        ),
+        ("target.check_model", "target/check_model_ref.rst"),
+        ("target.check_schema", "target/check_schema_ref.rst"),
+        ("target.index_model", "target/index_model_ref.rst"),
+        pytest.param(
+            "target.index_schema", "target/index_schema_ref.rst",
+            marks=pytest.mark.xfail(
+                reason="With this Sphinx version the schema instance does not have `isattr=True` so it is rejected by "
+                       "`DataDocumenter.can_document_member`. Besides it does not have the proper `__module__` "
+                       "attribute so it is rejected because of `check_module=True` in `documenter.generate`."
+            )
+        ),
+    ]
+)
+def test_entire_modules(module_path, rootdir, expected_rst_file, autodocument):
+    """Same as the two above, but this will go through the 'can_document_member' calls"""
+
+    expected_rst_file = rootdir / "test-basic" / expected_rst_file
+    expected_rst = expected_rst_file.read_text(encoding="utf-8")
+    actual_lines = autodocument(
+        documenter="module",
+        object_path=module_path,
+        all_members=True,
+        testroot="basic",
+        options_doc={"no-value": "", "undoc-members": ""},  # Disable value doc
+    )
+    actual_rst = "\n".join(actual_lines)
+    try:
+        assert actual_rst == expected_rst
+    except AssertionError as e:
+        # Write the file locally to easily modify the test ref file if needed.
+        expected_rst_file.with_suffix(".rst_actual").write_text(actual_rst, encoding="utf-8")
+        raise e from e
+    else:
+        actual_file = expected_rst_file.with_suffix(".rst_actual")
+        if actual_file.exists():
+            actual_file.unlink()
+
+
 ALL_DOCUMENTER_CLASSES = [
     PanderaSchemaDocumenter,
     PanderaModelDocumenter,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,13 @@
 import pytest
 
+from sphinx.ext.autodoc import ModuleDocumenter
+from sphinx.ext.autosummary import FakeDirective
+
+from sphinxcontrib.sphinx_pandera import PanderaModelDocumenter, PanderaSchemaDocumenter, PanderaModelConfigDocumenter, \
+    PanderaFieldDocumenter, PanderaCheckDocumenter
+from tests.symbols.basic_non_pandera import FooEnum, foo_func
+from tests.symbols import basic_model, basic_schema, check_model, check_schema, index_model, index_schema
+
 
 @pytest.mark.parametrize(
     "documenter,object_path,expected_rst",
@@ -563,3 +571,60 @@ def test_schema(documenter, object_path, expected_rst, autodocument):
         options_doc={"no-value": ""},  # Disable value doc
     )
     assert actual == expected_rst
+
+
+ALL_DOCUMENTER_CLASSES = [
+    PanderaSchemaDocumenter,
+    PanderaModelDocumenter,
+    PanderaModelConfigDocumenter,
+    PanderaFieldDocumenter,
+    PanderaCheckDocumenter
+]
+
+
+ALL_NON_PANDERA_SYMBOLS = [
+    FooEnum,
+    foo_func
+]
+
+ALL_PANDERA_SYMBOLS = (
+    (basic_model.TestModel, "pandera_model"),
+    (index_model.TestSingleIndexModel, "pandera_model"),
+    (index_model.TestMultiIndexModel, "pandera_model"),
+    (check_model.TestModel, "pandera_model"),
+    (check_model.TestModel.check_num_finess_format, "pandera_check"),
+    (check_model.TestModel.check_coords_non_null, "pandera_check"),
+    (basic_schema.basic_schema, "pandera_schema"),
+    (index_schema.single_index_schema, "pandera_schema"),
+    (index_schema.multi_index_schema, "pandera_schema"),
+    (check_schema.Evaluations, "pandera_schema"),
+    (check_schema.check_num_finess_format, "pandera_check"),
+    (check_schema.check_dataframe_coherence, "pandera_check"),
+)
+
+
+class TestCanDocumentMember:
+    @pytest.mark.parametrize("documenter_cls", ALL_DOCUMENTER_CLASSES)
+    @pytest.mark.parametrize("member,objtype", ALL_PANDERA_SYMBOLS)
+    def test_can_document_member_pandera_symbols(self, documenter_cls, member, objtype):
+        """Test that `can_document_member` does not crash."""
+
+        # Init parent (ModuleDocumenter)
+        parent = ModuleDocumenter(FakeDirective(), member.__module__)
+
+        if objtype == documenter_cls.objtype:
+            assert documenter_cls.can_document_member(member, '', False, parent)
+        else:
+            assert not documenter_cls.can_document_member(member, '', False, parent)
+
+
+    @pytest.mark.parametrize("documenter_cls", ALL_DOCUMENTER_CLASSES)
+    @pytest.mark.parametrize("member", ALL_NON_PANDERA_SYMBOLS)
+    def test_can_document_member_non_pandera_symbols(self, documenter_cls, member):
+        """Test that `can_document_member` does not crash when facing a non-pandera symbol."""
+
+        # Init parent (ModuleDocumenter)
+        parent = ModuleDocumenter(FakeDirective(), member.__module__)
+
+        # Make sure our documenter is robust to any kind of value
+        assert not documenter_cls.can_document_member(member, '', False, parent)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -619,6 +619,7 @@ def test_entire_modules(module_path, rootdir, expected_rst_file, autodocument):
         expected_rst_file.with_suffix(".rst_actual").write_text(actual_rst, encoding="utf-8")
         raise e from e
     else:
+        # Success - we can remove the local file if any
         actual_file = expected_rst_file.with_suffix(".rst_actual")
         if actual_file.exists():
             actual_file.unlink()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -588,34 +588,55 @@ ALL_NON_PANDERA_SYMBOLS = [
 ]
 
 ALL_PANDERA_SYMBOLS = (
-    (basic_model.TestModel, "pandera_model"),
-    (index_model.TestSingleIndexModel, "pandera_model"),
-    (index_model.TestMultiIndexModel, "pandera_model"),
-    (check_model.TestModel, "pandera_model"),
-    (check_model.TestModel.check_num_finess_format, "pandera_check"),
-    (check_model.TestModel.check_coords_non_null, "pandera_check"),
-    (basic_schema.basic_schema, "pandera_schema"),
-    (index_schema.single_index_schema, "pandera_schema"),
-    (index_schema.multi_index_schema, "pandera_schema"),
-    (check_schema.Evaluations, "pandera_schema"),
-    (check_schema.check_num_finess_format, "pandera_check"),
-    (check_schema.check_dataframe_coherence, "pandera_check"),
+    (basic_model.TestModel, PanderaModelDocumenter, False),
+    (index_model.TestSingleIndexModel, PanderaModelDocumenter, False),
+    (index_model.TestMultiIndexModel, PanderaModelDocumenter, False),
+    (check_model.TestModel, PanderaModelDocumenter, False),
+    pytest.param(
+        check_model.TestModel.check_num_finess_format, PanderaCheckDocumenter, False,
+        marks=pytest.mark.xfail(
+            reason="This has a parent that is a class, would need to create a classdocumenter")
+    ),
+    pytest.param(
+        check_model.TestModel.check_coords_non_null, PanderaCheckDocumenter, False,
+        marks=pytest.mark.xfail(
+            reason="This has a parent that is a class, would need to create a classdocumenter")
+    ),
+    (basic_schema.basic_schema, PanderaSchemaDocumenter, True),
+    (index_schema.single_index_schema, PanderaSchemaDocumenter, True),
+    (index_schema.multi_index_schema, PanderaSchemaDocumenter, True),
+    (check_schema.Evaluations, PanderaSchemaDocumenter, True),
+    pytest.param(
+        check_schema.check_num_finess_format, PanderaCheckDocumenter, False,
+        marks=pytest.mark.xfail(
+            reason="`PanderaCheckDocumenter` inherits from `MethodDocumenter`. `can_document_member` "
+                   "therefore returns False because the symbol is a function, not a method."
+        )
+    ),
+    pytest.param(
+        check_schema.check_dataframe_coherence, PanderaCheckDocumenter, False,
+        marks=pytest.mark.xfail(
+            reason="`PanderaCheckDocumenter` inherits from `MethodDocumenter`. `can_document_member` "
+                   "therefore returns False because the symbol is a function, not a method."
+        )
+    )
+    # TODO modelConfig and field
 )
 
 
 class TestCanDocumentMember:
     @pytest.mark.parametrize("documenter_cls", ALL_DOCUMENTER_CLASSES)
-    @pytest.mark.parametrize("member,objtype", ALL_PANDERA_SYMBOLS)
-    def test_can_document_member_pandera_symbols(self, documenter_cls, member, objtype):
+    @pytest.mark.parametrize("member,handled_by,isattr", ALL_PANDERA_SYMBOLS)
+    def test_can_document_member_pandera_symbols(self, autodocument, documenter_cls, member, handled_by, isattr):
         """Test that `can_document_member` does not crash."""
 
         # Init parent (ModuleDocumenter)
         parent = ModuleDocumenter(FakeDirective(), member.__module__)
 
-        if objtype == documenter_cls.objtype:
-            assert documenter_cls.can_document_member(member, '', False, parent)
+        if handled_by is documenter_cls:
+            assert documenter_cls.can_document_member(member, '', isattr, parent)
         else:
-            assert not documenter_cls.can_document_member(member, '', False, parent)
+            assert not documenter_cls.can_document_member(member, '', isattr, parent)
 
 
     @pytest.mark.parametrize("documenter_cls", ALL_DOCUMENTER_CLASSES)


### PR DESCRIPTION
Changelog :

- Fixed issue where `can_document_member` raises an `AttributeError` when facing a non-pandera symbol. Fixed #1.
- Fixed issue where `PanderaSchemaDocumenter.can_document_member` does not return `True` for a schema instance even when `isattr=True` 
- Added two new test suites
  - `test_basic.py::TestCanDocumentMember` is testing the classes outside of the sphinx documenter generation process. For this I made a copy of `test-docs/test-basic/target`, with an additional module, in `tests/symbols`. Its purpose is to have all symbols directly importable by the tests to perform low-level unit tests. An alternative would be to add the corresponding folder to `sys.path` dynamically in the tests. That would avoid the copy. Let me know if you prefer.
  -  `test_basic.py::test_entire_modules` documents the entire modules, thus also testing the `can_document_member` calls. This test relies on reference output files and writes the actual output file when there is a discrepancy, so that it is much more convenient to update the reference in case of failure. 

All the failing tests are marked with "xfail". As you can see from the `xfail` reason messages, the remaining failures are a blend of "not up-to-date sphinx version" and "errors in code".

I therefore opened #11 as sphinx version upgrade would be required before we move forward.

@Timost let me know how we can best move forward !


